### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A minimal MCP (Model Context Protocol) server template with hot reload support for development.
 
+<a href="https://glama.ai/mcp/servers/@currentspace/bootstrap_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@currentspace/bootstrap_mcp/badge" alt="Bootstrap Server MCP server" />
+</a>
+
 ## Features
 
 - **Hot Reload Proxy**: Maintains connection with Claude while allowing server restarts


### PR DESCRIPTION
This PR adds a badge for the [Bootstrap MCP Server](https://glama.ai/mcp/servers/@currentspace/bootstrap_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@currentspace/bootstrap_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@currentspace/bootstrap_mcp/badge" alt="Bootstrap Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.